### PR TITLE
Use -s option before or after argument

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -3,6 +3,7 @@
 var fs = require('fs')
 var path = require('path')
 var argv = require('yargs')
+        .boolean('s')
         .alias('s', 'silent')
         .describe('s', 'print empty string instead of erroring out')
         .argv


### PR DESCRIPTION
Makes it so this syntax works:

```
$ package-field -s <field>
```

Currently it only works like this:

```
$ package-field <field> -s
```
